### PR TITLE
Extract the qemu package via jq to avoid parsing issues

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,8 +8,8 @@ trap 'echo "An error occurred. Exiting..." >&2' ERR
 
 # Variables
 freebsd13_kernel="http://ftp-archive.freebsd.org/pub/FreeBSD-Archive/old-releases/amd64/13.1-RELEASE/kernel.txz"
-freebsd13_qga_pkg_version=$(curl -s "https://ports.freebsd.org/cgi/ports.cgi?query=qemu-guest-agent&stype=all&sektion=all" | grep -oE 'qemu-guest-agent-[0-9]+(\.[0-9]+)*(_[0-9]+)*' | head -1)
-freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/All/${freebsd13_qga_pkg_version}.pkg"
+freebsd13_qga_pkg_version=$(curl -s -L https://pkg.freebsd.org/FreeBSD:13:amd64/latest/data.txz | tar -OJxf - data | jq -r '.packages[] | select(.name=="qemu-guest-agent").repopath')
+freebsd13_qga_pkg="https://pkg.freebsd.org/FreeBSD:13:amd64/latest/${freebsd13_qga_pkg_version}"
 qga_backup_dir="/root/qga_backup"
 
 # Download FreeBSD 13.1 kernel.txz and extract virtio_console.ko driver to /boot/kernel


### PR DESCRIPTION
Same idea but using jq to parse the package data file and extract the repopath for the qemu package